### PR TITLE
feat(hasher): expose reset() and pre-allocate scratch buffers

### DIFF
--- a/src/hasher.ts
+++ b/src/hasher.ts
@@ -144,6 +144,17 @@ class ChunkState {
   }
 
   /**
+   * Re-seed this ChunkState without re-allocating chainingValue/blockWords.
+   */
+  resetTo(keyWords: Uint32Array, chunkCounter: number, flags: number): void {
+    this.chainingValue.set(keyWords);
+    this.chunkCounter = chunkCounter;
+    this.blockLen = 0;
+    this.blocksCompressed = 0;
+    this.flags = flags;
+  }
+
+  /**
    * Get the flags for the current block.
    */
   private startFlag(): number {
@@ -181,12 +192,10 @@ class ChunkState {
       const take = Math.min(want, inputLen);
 
       // Read bytes into block words
-      if (IS_LITTLE_ENDIAN && this.blockLen === 0 && take === BLOCK_LEN) {
-        // Fast path: aligned full block on little-endian
-        const inputWords = new Uint32Array(input.buffer, input.byteOffset + inputOffset, 16);
-        this.blockWords.set(inputWords);
-      } else if (this.blockLen === 0 && take === BLOCK_LEN) {
-        // Full block but big-endian or unaligned
+      if (this.blockLen === 0 && take === BLOCK_LEN) {
+        // Full block — byte-by-byte is empirically competitive and
+        // avoids a RangeError when (input.byteOffset + inputOffset) is
+        // not 4-aligned for a Uint32Array view.
         readLittleEndianWordsFull(input, inputOffset, this.blockWords);
       } else {
         // Partial block - byte-by-byte into correct position
@@ -265,6 +274,15 @@ export class Hasher {
   private cvStackLen: number;
   private flags: number;
 
+  // Reusable scratch buffers — allocated once, shared across update/finalize
+  // to eliminate per-chunk and per-finalize GC pressure. Safe because a Hasher
+  // is single-threaded and these buffers are never live across yield points.
+  private parentBlock: Uint32Array;
+  private parentCv: Uint32Array;
+  private chunkCv: Uint32Array;
+  private outWords: Uint32Array;
+  private finalizeCv: Uint32Array;
+
   /**
    * Create a new Hasher.
    *
@@ -277,6 +295,21 @@ export class Hasher {
     this.chunkState = new ChunkState(this.keyWords, 0, this.flags);
     this.cvStack = new Uint32Array(MAX_DEPTH * 8);
     this.cvStackLen = 0;
+    this.parentBlock = new Uint32Array(16);
+    this.parentCv = new Uint32Array(8);
+    this.chunkCv = new Uint32Array(8);
+    this.outWords = new Uint32Array(16);
+    this.finalizeCv = new Uint32Array(8);
+  }
+
+  /**
+   * Reset the hasher to process a new message with the same key/flags.
+   * Reuses all internal buffers — zero allocations.
+   */
+  reset(): this {
+    this.chunkState.resetTo(this.keyWords, 0, this.flags);
+    this.cvStackLen = 0;
+    return this;
   }
 
   /**
@@ -355,8 +388,8 @@ export class Hasher {
    */
   private addChunkCv(newCv: Uint32Array, newCvOffset: number, totalChunks: number): void {
     // Merge completed subtrees based on trailing zeros in chunk count
-    const parentBlock = new Uint32Array(16);
-    const parentCv = new Uint32Array(8);
+    const parentBlock = this.parentBlock;
+    const parentCv = this.parentCv;
 
     while ((totalChunks & 1) === 0) {
       // Pop left child, new CV is right child
@@ -399,7 +432,7 @@ export class Hasher {
       // If current chunk is full, finalize it and start a new one
       if (this.chunkState.len() === CHUNK_LEN) {
         const output = this.chunkState.output();
-        const chunkCv = new Uint32Array(8);
+        const chunkCv = this.chunkCv;
 
         compress(
           output.inputCv,
@@ -417,7 +450,7 @@ export class Hasher {
         const totalChunks = this.chunkState.chunkCounter + 1;
         this.addChunkCv(chunkCv, 0, totalChunks);
 
-        this.chunkState = new ChunkState(this.keyWords, totalChunks, this.flags);
+        this.chunkState.resetTo(this.keyWords, totalChunks, this.flags);
       }
 
       // Fill the current chunk
@@ -444,8 +477,8 @@ export class Hasher {
   } {
     // Finalize the current chunk
     let output = this.chunkState.output();
-    let parentBlock = new Uint32Array(16);
-    let cv = new Uint32Array(8);
+    let parentBlock = this.parentBlock;
+    let cv = this.finalizeCv;
 
     // If there are chunks on the stack, merge them
     if (this.cvStackLen > 0) {
@@ -511,7 +544,7 @@ export class Hasher {
 
     if (outputLength <= 64) {
       // Single block output
-      const outWords = new Uint32Array(16);
+      const outWords = this.outWords;
       compress(
         output.inputCv,
         0,

--- a/test/reset.test.ts
+++ b/test/reset.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for Hasher.reset() and buffer reuse across finalize/reset cycles.
+ *
+ * Workload context: Hugging Face Xet content-defined chunking hashes many
+ * small chunks in a tight loop; reset() avoids re-allocating Hasher state
+ * per chunk.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { hash, createHasher, createKeyed, createDeriveKey, Hasher } from "../src/index.js";
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function generateInput(length: number): Uint8Array {
+  const input = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    input[i] = i % 251;
+  }
+  return input;
+}
+
+describe("Hasher.reset()", () => {
+  it("matches a fresh Hasher after reset for small inputs", () => {
+    const a = generateInput(100);
+    const b = generateInput(500);
+
+    const hasher = createHasher();
+    hasher.update(a);
+    const first = hasher.finalize();
+    expect(bytesToHex(first)).toBe(bytesToHex(hash(a)));
+
+    hasher.reset();
+    hasher.update(b);
+    const second = hasher.finalize();
+    expect(bytesToHex(second)).toBe(bytesToHex(hash(b)));
+  });
+
+  it("matches a fresh Hasher after reset across chunk boundaries", () => {
+    // 2 KiB crosses a chunk boundary (CHUNK_LEN = 1024)
+    const first = generateInput(2048);
+    // 8 KiB triggers SIMD path (SIMD_THRESHOLD = 4 KiB)
+    const second = generateInput(8192);
+
+    const hasher = createHasher();
+    hasher.update(first);
+    expect(bytesToHex(hasher.finalize())).toBe(bytesToHex(hash(first)));
+
+    hasher.reset();
+    hasher.update(second);
+    expect(bytesToHex(hasher.finalize())).toBe(bytesToHex(hash(second)));
+  });
+
+  it("preserves keyed-hash flags across reset", () => {
+    const key = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) key[i] = i;
+
+    const m1 = generateInput(73);
+    const m2 = generateInput(2000);
+
+    const keyed = createKeyed(key);
+    keyed.update(m1);
+    const mac1 = keyed.finalize();
+    expect(bytesToHex(mac1)).toBe(bytesToHex(Hasher.newKeyed(key).update(m1).finalize()));
+
+    keyed.reset();
+    keyed.update(m2);
+    const mac2 = keyed.finalize();
+    expect(bytesToHex(mac2)).toBe(bytesToHex(Hasher.newKeyed(key).update(m2).finalize()));
+  });
+
+  it("preserves derive_key context across reset", () => {
+    const context = "blake3-jit reset test v1";
+    const ikm1 = generateInput(32);
+    const ikm2 = generateInput(1500);
+
+    const kdf = createDeriveKey(context);
+    kdf.update(ikm1);
+    const derived1 = kdf.finalize(64);
+    expect(bytesToHex(derived1)).toBe(
+      bytesToHex(createDeriveKey(context).update(ikm1).finalize(64)),
+    );
+
+    kdf.reset();
+    kdf.update(ikm2);
+    const derived2 = kdf.finalize(64);
+    expect(bytesToHex(derived2)).toBe(
+      bytesToHex(createDeriveKey(context).update(ikm2).finalize(64)),
+    );
+  });
+
+  it("returns `this` for chaining", () => {
+    const hasher = createHasher();
+    hasher.update(generateInput(10));
+    hasher.finalize();
+    const chained = hasher.reset().update(generateInput(20)).finalize();
+    expect(chained.length).toBe(32);
+  });
+
+  it("handles many reset cycles without drift", () => {
+    const hasher = createHasher();
+    for (let i = 0; i < 50; i++) {
+      const input = generateInput(i * 17 + 1);
+      hasher.reset();
+      hasher.update(input);
+      expect(bytesToHex(hasher.finalize())).toBe(bytesToHex(hash(input)));
+    }
+  });
+});
+
+describe("ChunkState unaligned input", () => {
+  // Regression: the LE fast-path used `new Uint32Array(input.buffer, byteOffset, 16)`
+  // which throws RangeError when byteOffset is not 4-aligned.
+  it("incrementally hashes with an odd byteOffset", () => {
+    const raw = new Uint8Array(1025);
+    for (let i = 0; i < raw.length; i++) raw[i] = i % 251;
+    // subarray(1) makes byteOffset === 1 — misaligned for a Uint32Array view.
+    const misaligned = raw.subarray(1);
+
+    const hasher = createHasher();
+    hasher.update(misaligned);
+    const digest = hasher.finalize();
+
+    // Compare against a fresh aligned copy.
+    const aligned = new Uint8Array(misaligned);
+    expect(bytesToHex(digest)).toBe(bytesToHex(hash(aligned)));
+  });
+});


### PR DESCRIPTION
Ports the changes from the @huggingface/blake3-jit fork (issue #34) to reduce per-hash GC pressure in workloads that hash many small messages (e.g. Hugging Face Xet content-defined chunking).

- Hasher.reset() re-seeds chunk state and clears the CV stack with zero allocations, enabling reuse across messages with the same key/flags.
- ChunkState.resetTo() avoids re-allocating chainingValue/blockWords on chunk boundaries; wired into Hasher.update() at the 1 KiB rollover.
- Pre-allocated parentBlock/parentCv/chunkCv/outWords/finalizeCv fields replace per-call Uint32Array allocations in addChunkCv/update/ finalizeOutput/finalize.
- Drop the unaligned Uint32Array view fast-path in ChunkState.update(), which threw RangeError when input.byteOffset+inputOffset was not 4-aligned; byte-by-byte read is empirically competitive.